### PR TITLE
`BarcodeHandler.from_file`: Pass down parameters

### DIFF
--- a/demuxalot/utils.py
+++ b/demuxalot/utils.py
@@ -77,12 +77,13 @@ class BarcodeHandler:
         return self.barcode2index.get(barcode, None)
 
     @staticmethod
-    def from_file(barcodes_filename):
+    def from_file(barcodes_filename, **kwargs):
         """
         :param barcodes_filename: path to barcodes.csv or barcodes.csv.gz where each line is a barcode
+        :param **kwargs: optional additional keyword arguments to pass down to BarcodeHandler.__init__
         """
         barcodes = pd.read_csv(barcodes_filename, header=None)[0].values
-        return BarcodeHandler(barcodes)
+        return BarcodeHandler(barcodes, **kwargs)
 
     def filter_to_rg_value(self, rg_value):
         """ Create a copy of this handler with only barcodes specific to one original file described by RG tag """


### PR DESCRIPTION
While `BarcodeHandler.__init__` has (optional) parameters to adjust barcode-related options (*e.g.* using non-`CB` SAM tags for the cell barcodes, like `XC`), the static `from_file` function called it without any of those parameters, making it impossible to adjust them when using that function.
This is resolved by adding an optional keyword argument dictionary parameters to the static function and passing all argument provided therein, if any, down to the `__init__` call.

This addresses one out of two issues raised in https://github.com/herophilus/demuxalot/issues/23.

---
closes #26