### PR TITLE
change molecule_index datatype from int32 to int64

### DIFF
--- a/demuxalot/snp_counter.py
+++ b/demuxalot/snp_counter.py
@@ -87,7 +87,7 @@ class CompressedSNPCalls:
         self.n_molecules = 0
         self.molecules = np.array(
             [(-1, -1, -1.)] * start_molecule_size,
-            dtype=[('compressed_cb', 'int32'), ('compressed_ub', 'int32'), ('p_group_misaligned', 'float32')]
+            dtype=[('compressed_cb', 'int64'), ('compressed_ub', 'int64'), ('p_group_misaligned', 'float32')]
         )
 
         self.n_snp_calls = 0


### PR DESCRIPTION
Hi. Thanks so much for your software. I have used it extensively in 10X scRNA-Seq datasets.

Recently, upon attempting to use demuxalot in a dataset generated by [Cell Ranger ARC](https://www.10xgenomics.com/support/software/cell-ranger-arc/latest), I encountered an integer overflow error like the one below:

```bash
Traceback (most recent call last):
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/joblib/externals/loky/process_executor.py", line 490, in _process_worker
    r = call_item()
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/joblib/externals/loky/process_executor.py", line 291, in __call__
    return self.fn(*self.args, **self.kwargs)
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/joblib/parallel.py", line 607, in __call__
    return [func(*args, **kwargs) for func, args, kwargs in self.items]
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/joblib/parallel.py", line 607, in <listcomp>
    return [func(*args, **kwargs) for func, args, kwargs in self.items]
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/demuxalot/snp_counter.py", line 268, in count_call_variants_for_chromosome
    compress_groups_of_molecule_reads(
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/demuxalot/snp_counter.py", line 223, in compress_groups_of_molecule_reads
    compressed_snp_calls.add_calls_from_read_group(cbub[0], cbub[1], p_group_misaligned, snips)
  File "/home/mschechter/miniconda3/envs/barreiro/lib/python3.10/site-packages/demuxalot/snp_counter.py", line 107, in add_calls_from_read_group
    self.molecules[molecule_index] = (compressed_cb, compressed_ub, p_group_misaligned)
OverflowError: Python integer 4135497516 out of bounds for int32
"""
```

I tried reducing the number of SNPs in my VCF, as well as comparing the number of reads in my BAM file to other datasets I had successfully ran demuxalot with in case it was a problem related to the size of my input files (but I ended up discovering that my Cell Ranger ARC files are actually smaller in size). Nonetheless, I kept getting the error.

Eventually, I figured out that the problem was an integer overflow caused by how demuxalot computes and stores the molecule_index variable. For some reason, the barcodes used by Single Cell Multiome ATAC + Gene Expression methods are different enough from an standard 10X scRNA-seq protocol that they caused the integer overflow. So to fix it, i modified demuxalot's source such as CB and UB can be coded as int64 (instead of the default int32).
