### PR TITLE
Support longer UB codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Below is a benchmark on PMBC data with 32 donors from [preprint](https://www.bio
 
 <img width="1434" alt="Screen Shot 2021-06-03 at 6 03 12 PM" src="https://user-images.githubusercontent.com/6318811/120730293-07cdd300-c496-11eb-8a9c-62c8b8cf9847.png">
 
+Remark: we used `demuxalot` internally for a number of challenging scenarios with a large biobank and low-depth sequencing, 
+and it shines in these scenarios too. Actually, that's why it was created in the first place.
 
 
 ## Known genotypes and refined genotypes: the tale of two scenarios

--- a/demuxalot/utils.py
+++ b/demuxalot/utils.py
@@ -18,8 +18,8 @@ def hash_string(s) -> int:
     for c in s:
         result *= 5
         result += ord(c)
-    return result
-
+    # make sure we fit into int32, as a residue by largest prime below 2 ** 32 - 1
+    return result % 2147483629
 
 base_lookup = {'A': 0, 'C': 1, 'G': 2, 'T': 3, 'N': 4}
 
@@ -32,7 +32,7 @@ def decompress_base(base_index: int) -> str:
     return 'ACGTN'[base_index]
 
 
-def fast_np_add_at_1d(x, indices, weights):
+def fast_np_add_at_1d(x, indices, weights) -> None:
     x[:] = x + np.bincount(indices, weights=weights, minlength=len(x))
 
 


### PR DESCRIPTION
fix problem reported in #35

- context: 12-AA UB barcodes were encoded as integers >= 2 ** 32, which conflicts with using 32-bit integers downstream. 
- minor remark about internal usage

cc @danielsarj